### PR TITLE
Fix StampedLock optimistic read

### DIFF
--- a/src/jmh/java/com/github/andrebrait/workshops/jmh/presentation/examples/LockBenchmark.java
+++ b/src/jmh/java/com/github/andrebrait/workshops/jmh/presentation/examples/LockBenchmark.java
@@ -336,10 +336,8 @@ public class LockBenchmark {
 
         public long get() {
             long stamp = lock.tryOptimisticRead();
-            long currentCount;
-            if (lock.validate(stamp)) {
-                currentCount = counter;
-            } else {
+            long currentCount = counter;
+            if (!lock.validate(stamp)) {
                 stamp = lock.readLock();
                 try {
                     currentCount = counter;


### PR DESCRIPTION
We should get `counter` and then validate `stamp`